### PR TITLE
fix(vercel): ESM-safe relative imports with .js extensions; NodeNext resolution

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 // Explicit .js extension for Node ESM on Vercel
 import { storage } from "./storage.js";
-import { insertContactSchema, insertBookingSchema, insertQuoteSchema, insertBlogPostSchema } from "@shared/schema";
+import { insertContactSchema, insertBookingSchema, insertQuoteSchema, insertBlogPostSchema } from "../shared/schema.js";
 import { z } from "zod";
 
 export async function registerRoutes(app: Express): Promise<Server> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,13 +9,12 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Aliases for your project structure */
     "baseUrl": ".",
     "paths": {
@@ -38,6 +37,5 @@
     "tailwind.config.ts",
     "**/*.test.ts",
     "**/*.test.tsx"
-  ],
-  
+  ]
 }


### PR DESCRIPTION
## Fix Vercel ESM Import Issues

This PR fixes the ESM module resolution errors occurring on Vercel deployment that were causing `ERR_MODULE_NOT_FOUND` errors.

### Changes Made:

1. **Updated TypeScript Configuration:**
   - Changed `"module": "ESNext"` to `"module": "NodeNext"`
   - Changed `"moduleResolution": "bundler"` to `"moduleResolution": "NodeNext"`
   - This ensures proper ESM module resolution for Node.js environments

2. **Fixed Import Paths:**
   - Replaced path alias `@shared/schema` with relative ESM import `../shared/schema.js`
   - Added explicit `.js` extension for proper ESM resolution
   - All server-side imports now use relative paths with proper extensions

### Problem Solved:
The deployment was failing with errors like:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/server/routes' imported from /var/task/server/index.js
```

These changes ensure that all server-side modules can be properly resolved at runtime on Vercel's Node.js environment.